### PR TITLE
changed deprecated boundActionCreators to actions

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -5,7 +5,7 @@ const nodeHelpers = createNodeHelpers({ typePrefix: "Yotpo" });
 const { createNodeFactory, generateNodeId } = nodeHelpers;
 
 export const sourceNodes = async (
-  { boundActionCreators: { createNode } },
+  { actions: { createNode } },
   pluginOptions
 ) => {
   if (!pluginOptions.appKey) {


### PR DESCRIPTION
There is an issue #5 where this plugin doesn't work for Gatsby v3.

Per the [Gatsby v2 to v3 migration guide](https://www.gatsbyjs.com/docs/reference/release-notes/migrating-from-v2-to-v3/#removal-of-boundactioncreators):

> The deprecated API boundActionCreators was removed. Please rename its instances to actions to keep the same behavior.

I have changed the instance of boundActionCreators in gatsby-node.js to actions. I have tested it locally and it works as expected.